### PR TITLE
Fix: add missing libyaml for dtc

### DIFF
--- a/pkgs/xilinx-fhs.nix
+++ b/pkgs/xilinx-fhs.nix
@@ -27,6 +27,7 @@ buildFHSUserEnv {
     (ncurses'.override { unicodeSupport = false; })
     stdenv.cc.cc
     zlib
+    libyaml
 
     # gui libraries
     fontconfig


### PR DESCRIPTION
The dtc included in the xilinx installation complains about a missing libyaml.