### PR TITLE
Fix noBrokenSymlinks error

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -22,11 +22,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1744440957,
-        "narHash": "sha256-FHlSkNqFmPxPJvy+6fNLaNeWnF1lZSgqVCl/eWaJRc4=",
+        "lastModified": 1747485343,
+        "narHash": "sha256-YbsZyuRE1tobO9sv0PUwg81QryYo3L1F3R3rF9bcG38=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "26d499fc9f1d567283d5d56fcf367edd815dba1d",
+        "rev": "9b5ac7ad45298d58640540d0323ca217f32a6762",
         "type": "github"
       },
       "original": {
@@ -50,11 +50,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744961264,
-        "narHash": "sha256-aRmUh0AMwcbdjJHnytg1e5h5ECcaWtIFQa6d9gI85AI=",
+        "lastModified": 1747469671,
+        "narHash": "sha256-bo1ptiFoNqm6m1B2iAhJmWCBmqveLVvxom6xKmtuzjg=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "8d404a69efe76146368885110f29a2ca3700bee6",
+        "rev": "ab0378b61b0d85e73a8ab05d5c6029b5bd58c9fb",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -61,7 +61,7 @@
                 owner = "Xilinx";
                 repo = "u-boot-xlnx";
                 rev = "xlnx_rebase_v2025.01";
-                hash = "sha256-ToA+ossw2pSX5FXq3N9DjVR6MEhZUsYKCp4Q9BZ46h4=";
+                hash = "sha256-RTcd7MR37E4yVGWP3RMruyKBI4tz8ex7mY1f5F2xd00=";
               };
             };
           })

--- a/xilinx-unified/xilinx-fhs.nix
+++ b/xilinx-unified/xilinx-fhs.nix
@@ -1,4 +1,4 @@
-{ buildFHSUserEnv }:
+{ buildFHSEnv }:
 
 {
   name ? "xilinx-fhs",
@@ -7,7 +7,7 @@
 }:
 
 # Inspired by: https://github.com/nix-community/nix-environments
-buildFHSUserEnv {
+buildFHSEnv {
   inherit name runScript profile;
   targetPkgs =
     pkgs:

--- a/xilinx-unified/xilinx-unified.nix
+++ b/xilinx-unified/xilinx-unified.nix
@@ -4,6 +4,7 @@
   genXilinxFhs,
   rapidgzip,
   ripgrep,
+  sd,
   xorg,
 
   name,
@@ -42,6 +43,7 @@ stdenv.mkDerivation (
     nativeBuildInputs = [
       rapidgzip
       ripgrep
+      sd
       xorg.xorgserver
       (genXilinxFhs { })
     ];
@@ -118,9 +120,15 @@ stdenv.mkDerivation (
         substituteInPlace "$file" \
           --replace-fail ${lib.strings.escapeShellArg uniqueTargetDir} "$out"
       done < <(rg --null --files-with-matches ${lib.strings.escapeShellArg uniqueTargetDir} "$out")
+
+      # Fix symlinks
+      find $out/ -xtype l -exec bash -c ' \
+        link={}; \
+        target=$(readlink {} | sd ${lib.strings.escapeShellArg uniqueTargetDir} "$out"); \
+        echo "Fixing $link -> $target"; \
+        rm $link; \
+        ln -s $target $link' \;
     '';
-    # sed 's:'${lib.strings.escapeShellArg uniqueTargetDir}":$out:g" \
-    #   --in-place -- "$file"
 
     dontPatchELF = true;
     dontPatchShebangs = true;


### PR DESCRIPTION
When moving the installation from the unique_install_dir to $out some symlinks break, triggering the noBrokenSymlinks hook in the fixup phase. This PR fixes that, by searching and replacing the broken symlinks in preFixup.